### PR TITLE
sourcing hooks + dry run feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ To avoid that we need to use this order:
 * lines starting with `#` are ignored.
 * you can override config filename using `CROWDR_CFG` variable
 * you can enable debug mode using `CROWDR_TRACE` variable
+* review planned commands without executing them using `CROWDR_DRY` variable
+
+> example: CROWDR_CFG=/foo/crowdr.cfg.sh CROWDR_DRY=1 crowdr run
 
 Sample `crowdr.cfg.sh`:
 ```bash

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To avoid that we need to use this order:
 * you can enable debug mode using `CROWDR_TRACE` variable
 * review planned commands without executing them using `CROWDR_DRY` variable
 
-> example: CROWDR_CFG=/foo/crowdr.cfg.sh CROWDR_DRY=1 crowdr run
+> example: CROWDR_CFG=/foo/crowdr.cfg.sh CROWDR_DRY=1 crowdr run 2>&1 | more
 
 Sample `crowdr.cfg.sh`:
 ```bash

--- a/crowdr
+++ b/crowdr
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-[[ -n "$CROWDR_TRACE" ]] && set -x
+[[ -n "$CROWDR_TRACE" || -n "$CROWDR_DRY" ]] && set -x
+[[ -n "$CROWDR_DRY"   ]] && { alias docker='echo docker'; shopt -s expand_aliases; HOOKEXEC=cat;} || HOOKEXEC=source
 CROWDR_CFG=${CROWDR_CFG:-crowdr.cfg.sh}
 CROWDR_DIR="$(dirname CROWDR_CFG)"
 CROWDR_HOOKDIR="$CROWDR_DIR/hooks"
@@ -128,6 +129,6 @@ parse_cfg() {
 cmd="${1:-run}"
 shift
 parse_cfg
-[[ -x $CROWDR_HOOKDIR/$cmd.before ]] && $CROWDR_HOOKDIR/$cmd.before
+[[ -x $CROWDR_HOOKDIR/$cmd.before ]] && $HOOKEXEC $CROWDR_HOOKDIR/$cmd.before
 command_$cmd "$@"
-[[ -x $CROWDR_HOOKDIR/$cmd.after ]] && $CROWDR_HOOKDIR/$cmd.after
+[[ -x $CROWDR_HOOKDIR/$cmd.after ]] && $HOOKEXEC $CROWDR_HOOKDIR/$cmd.after


### PR DESCRIPTION
I ran into a situation where crowdr became hard to use with >5 containers (takes docker a long time).
Therefore, I needed to review the performed docker commands upfront, in other words a dry-run (like rsync's --dry-run).

```
CROWDR_DRY=1 crowdr run
```

This will show exactly which docker commands would be executed _including_ the hooks, without actually executing them.

This feature made me realize the need of another feature: sourcing hooks instead of executing them in a seperate process. Now the hooks can use (env)variables from the crowdr script.

Luckily both features could be implemented by adding one extra line.

Cheers
