### PR TITLE
Add project_sep global option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,17 +124,30 @@ Benefits:
 * bash support :trollface:
 * full `docker run` options support
 
-### Global options
-
-Currently only `project` option is supported.
+### `project` option (global)
 
 ```
 global project myproject
 ```
 
-If it is not set current directory name used.
+Global option for name of project. All container names will be silently prefixed with this name and separator char. If it is not set current directory name used.
 
-### Build option
+### `project_sep` option (global)
+
+```
+global project_sep "_"
+```
+
+Separator string used after project name. If it is not set `_` is used.
+
+For example for following configuration all containers will be prefixed with `myproj-`
+
+```
+global project myproj
+global project_sep "-"
+```
+
+### `build` option
 
 `build` - path to a directory containing a Dockerfile
 
@@ -142,7 +155,7 @@ If it is not set current directory name used.
 container_name build some/path
 ```
 
-### Image option
+### `image` option
 
 `image` - image name. If image doesn't exists docker will try to download it.
 
@@ -150,7 +163,7 @@ container_name build some/path
 container_name image ubuntu:14.04
 ```
 
-### Command option
+### `command` option
 
 `command` - overrides `CMD` from Dockerfile/image
 

--- a/crowdr
+++ b/crowdr
@@ -84,19 +84,19 @@ command_ip() {
 
 command_shell() {
     local name="$1"
-    $DOCKER_BIN exec -it ${opts_global[project]}_$name bash
+    $DOCKER_BIN exec -it ${opts_global[project]}${opts_global[project_sep]}$name bash
 }
 
 command_exec() {
     local name="$1"
     shift
-    $DOCKER_BIN exec -it ${opts_global[project]}_$name "$@"
+    $DOCKER_BIN exec -it ${opts_global[project]}${opts_global[project_sep]}$name "$@"
 }
 
 command_pipe() {
     local name="$1"
     shift
-    $DOCKER_BIN exec -i ${opts_global[project]}_$name "$@"
+    $DOCKER_BIN exec -i ${opts_global[project]}${opts_global[project_sep]}$name "$@"
 }
 
 command_restart() {
@@ -130,13 +130,14 @@ parse_cfg() {
     local value=""
     local link=""
     local alias=""
+    opts_global[project_sep]="_"
     opts_global[project]=$(basename $PWD)
     while read container option value; do
         if [[ "$container" == "global" ]]; then
             opts_global[$option]="$value"
             continue
         fi
-        container="${opts_global[project]}_$container"
+        container="${opts_global[project]}${opts_global[project_sep]}$container"
         deps+=("$container $container")
         case $option in
             command)
@@ -153,7 +154,7 @@ parse_cfg() {
                 ;;
             link)
                 link="${value%%:*}"
-                link="${opts_global[project]}_$link"
+                link="${opts_global[project]}${opts_global[project_sep]}$link"
                 alias="${value##*:}"
                 deps+=("$container $link")
                 value="$link:$alias"


### PR DESCRIPTION
Crowdr forces to use underscore character in container names. If you want to use [dnsdocks](https://github.com/tonistiigi/dnsdock) together with crowdr then you are also forced to have underscore character in host names. Unfortunately underscores are not allowed in DNS host names according to RFCs 1034 and 1035. It can cause some troubles. For example in case of Apache Kafka client you need to use `bootstrap.servers` configuration parameter which in case of using dnsdock and crowdr could be something like
`myproj_kafka01.docker:9020,myproj_kafka03.docker:9020,myproj_kafka03.docker:9020`
This value will not be parsed correctly by Apache Kafka client because regex expression used for that purpose in client source code does not assume existence of underscores in host names (and this assumption is fine according to RFCs 1034 and 1035).

Therefore crowdr should provide a way to replace underscore with some other character.

In this pull request I added option 'project_sep' which is separator string used after project name. If it is not set `_` is used. This change is backward compatible.
