### PR TITLE
Ordering from config. Container hooks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+## [0.9.0](https://github.com/polonskiy/crowdr/tree/0.9.0) (2015-12-31)
+
+[Full changelog](https://github.com/polonskiy/crowdr/compare/0.8.3...0.9.0)
+
+- added configurable project separator
+- added container hooks (build/run/rmi)
+- containers run order depends on config (backward incompatible)
+- added changelog

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crowdr
 
-Crowdr is a tool for managing multiple Docker containers.
+Crowdr is a extremely flexible tool for managing multiple Docker containers.
 
 ## Why not bash/make?
 
@@ -52,8 +52,8 @@ To avoid that we need to use this order:
 ## Installation
 
 ```
-# curl -s https://raw.githubusercontent.com/polonskiy/crowdr/master/crowdr > /usr/local/bin/crowdr
-# curl -s https://raw.githubusercontent.com/polonskiy/crowdr/master/completion > /etc/bash_completion.d/crowdr
+# curl -s https://raw.githubusercontent.com/polonskiy/crowdr/0.9.0/crowdr > /usr/local/bin/crowdr
+# curl -s https://raw.githubusercontent.com/polonskiy/crowdr/0.9.0/completion > /etc/bash_completion.d/crowdr
 ```
 
 ## Crowdr commands
@@ -94,6 +94,7 @@ To avoid that we need to use this order:
 * you can override config filename using `CROWDR_CFG` variable (`CROWDR_CFG=~/foo/bar/baz.sh crowdr`)
 * you can enable debug mode using `CROWDR_TRACE` variable (`CROWDR_TRACE=1 crowdr |& less`)
 * review planned commands without executing them using `CROWDR_DRY` variable (`CROWDR_DRY=1 crowdr |& less`)
+* containers run in the order as in config, stop in reversed
 
 Sample `.crowdr/config.sh`:
 ```bash
@@ -194,11 +195,6 @@ Lets say you want to pull in some Dockerfiles from remote repositories *before* 
     pulling repos
 
 Crowdr detects both `.before` and `.after`-hooks of each crowdr command.
-
-### Internal magic
-
-* all container names will silently prefixed with `projectname_`
-* dependencies: if `foo` links to `bar`, then `bar` will started before `foo` and stopped after `foo`
 
 ## Not supported (yet)
 

--- a/crowdr
+++ b/crowdr
@@ -22,7 +22,6 @@ declare -A opts_build
 declare -A opts_global
 declare -A opts_image
 declare -A opts_command
-deps=()
 list=""
 
 trap exit INT
@@ -138,7 +137,7 @@ parse_cfg() {
             continue
         fi
         container="${opts_global[project]}${opts_global[project_sep]}$container"
-        deps+=("$container $container")
+        names+=("$container")
         case $option in
             command)
                 opts_command[$container]=$value
@@ -156,13 +155,12 @@ parse_cfg() {
                 link="${value%%:*}"
                 link="${opts_global[project]}${opts_global[project_sep]}$link"
                 alias="${value##*:}"
-                deps+=("$container $link")
                 value="$link:$alias"
                 ;;
         esac
         opts_run[$container]+=" --$option=$value"
     done < <(. $CROWDR_CFG | grep -vP '(^#)|(^$)')
-    list="$(printf '%s\n' "${deps[@]}" | tsort | tac)"
+    list="$(printf '%s\n' "${names[@]}" | uniq )"
 }
 
 cmd="${1:-run}"

--- a/crowdr
+++ b/crowdr
@@ -36,9 +36,9 @@ run_hook(){
 command_build() {
     for c in $list; do
         if [[ -n "${opts_build[$c]}" ]]; then
-            run_hook $c build.before
+            run_hook $c before.build
             $DOCKER_BIN build -t $c ${opts_build[$c]} || exit
-            run_hook $c build.after
+            run_hook $c after.build
         fi
     done
 }
@@ -53,11 +53,11 @@ command_run() {
         | sed 's|^/||' \
         | xargs --no-run-if-empty docker rm -f > /dev/null
     for c in $list; do
-        run_hook $c run.before
+        run_hook $c before.run
         image=$c
         [[ -n "${opts_image[$c]}" ]] && image="${opts_image[$c]}"
         $DOCKER_BIN run -d -t --name $c ${opts_run[$c]} "$image" ${opts_command[$c]} > /dev/null && echo $c
-        run_hook $c run.after
+        run_hook $c after.run
     done
 }
 
@@ -85,7 +85,6 @@ command_ip() {
     local ip=""
     local running=""
     for c in $list; do
-        
         running=$($DOCKER_BIN inspect --format '{{.State.Running}}' $c)
         ip=$($DOCKER_BIN inspect --format '{{ .NetworkSettings.IPAddress }}' $c)
         [[ "$running" == "false" ]] && ip=""
@@ -129,11 +128,11 @@ command_rm() {
 command_rmi() {
     local image=""
     for c in $list; do
-        run_hook $c rmi.before
+        run_hook $c before.rmi
         image=$c
         [[ -n "${opts_image[$c]}" ]] && image="${opts_image[$c]}"
         $DOCKER_BIN rmi "${image}"
-        run_hook $c rmi.after
+        run_hook $c after.rmi
     done
 }
 
@@ -145,6 +144,7 @@ parse_cfg() {
     local alias=""
     local hook_name=""
     local hook_script=""
+    local names=()
     opts_global[project_sep]="_"
     opts_global[project]=$(basename $PWD)
     while read container option value; do
@@ -173,10 +173,8 @@ parse_cfg() {
                 alias="${value##*:}"
                 value="$link:$alias"
                 ;;
-            hook)
-                hook_name=$(echo "$value"|awk '{print $1}')
-                hook_script=$(echo "$value"|awk '{$1=""; print $0}')
-                opts_hook["$container~$hook_name"]="$hook_script"
+            after.*|before.*)
+                opts_hook["$container~$option"]="$value"
                 continue
                 ;;
         esac


### PR DESCRIPTION
Based on #8 #10 

I have changed container hooks naming.
I think format `redis hook run.after sleep 5` is too confusing. Run after sleep?
Changed to `redis after.run sleep 5`.

I know. It is inconsistent with global hooks.

Any comments?
@coderofsalvation @byrnedo @marcinwaldowski
