### PR TITLE
Add missing container hooks

### DIFF
--- a/crowdr
+++ b/crowdr
@@ -58,19 +58,29 @@ command_run() {
         | xargs --no-run-if-empty docker rm -f > /dev/null
     for c in $list; do
         run_hook $c before.run
+        run_hook $c before.start
         image=$c
         [[ -n "${opts_image[$c]}" ]] && image="${opts_image[$c]}"
         $DOCKER_BIN run -d -t --name $c ${opts_run[$c]} "$image" ${opts_command[$c]} > /dev/null && echo $c
+        run_hook $c after.start
         run_hook $c after.run
     done
 }
 
 command_start() {
-    $DOCKER_BIN start $list
+    for c in $list; do
+        run_hook $c before.start
+        $DOCKER_BIN start $c
+        run_hook $c after.start
+    done
 }
 
 command_stop() {
-    $DOCKER_BIN stop $(tac <<< "$list")
+    for c in $(tac <<< "$list"); do
+        run_hook $c before.stop
+        $DOCKER_BIN stop $c
+        run_hook $c after.stop
+    done
 }
 
 command_stats() {
@@ -115,18 +125,26 @@ command_pipe() {
 
 command_restart() {
     echo "Stopping..."
-    $DOCKER_BIN stop $(tac <<< "$list")
+    command_stop
     echo
     echo "Starting..."
-    $DOCKER_BIN start $list
+    command_start
 }
 
 command_kill() {
-    $DOCKER_BIN kill $(tac <<< "$list")
+    for c in $(tac <<< "$list"); do
+        run_hook $c before.kill
+        $DOCKER_BIN kill $c
+        run_hook $c after.kill
+    done
 }
 
 command_rm() {
-    $DOCKER_BIN rm $(tac <<< "$list")
+    for c in $(tac <<< "$list"); do
+        run_hook $c before.rm
+        $DOCKER_BIN rm $c
+        run_hook $c after.rm
+    done
 }
 
 command_rmi() {


### PR DESCRIPTION
Missing implementation of container hooks for commands: `start`, `stop`, `restart`, `kill` and `rm`.

We do not need container hooks for commands `version`, `stats`, `ps` and `ip`.

@polonskiy, @coderofsalvation, @byrnedo, @superm00s: 
Does anyone have use case for container hooks for command `shell`, `exec` or `pipe`?
