### PR TITLE
New version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ Yes, that's all. No need for additional libraries or execution environments.
 
 # Quick-start guide
 
-Crowdr can be used both with the newest features of docker 1.9 (like [named values](https://docs.docker.com/engine/userguide/dockervolumes/#mount-a-host-directory-as-a-data-volume) and [user-defined networks](https://docs.docker.com/engine/userguide/networking/dockernetworks/#user-defined-networks)) as with the older version of docker.
-
-### Docker 1.9 example
+### Example
 
 The following example runs simple but complete [Wordpress](https://wordpress.org/) installation on Docker which contains:
 - user defined network `example01` used by all containers,
@@ -124,10 +122,6 @@ It uses only official docker containers, so it can be used easily to play with c
   - `docker volume rm example01-wordpress-db` - to remove named volume with database data
   - `docker volume rm example01-wordpress-web` - to remove named volume with Wordpress html data
   - `docker network rm example01` - to remove user defined network
-
-### Docker <1.9 example
-
-Comming soon...
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -298,13 +298,13 @@ Every crowdr command can be extended.
 Lets say you want to pull in some Dockerfiles from remote repositories *before* running `crowdr build`.
 
     $ mkdir .crowdr/hooks
-    $ echo 'echo pulling repos' > .crowdr/hooks/build.before
-    $ echo 'git clone http://github.com/someuser/docker.redis' >> .crowdr/hooks/build.before
-    $ echo 'git clone http://github.com/someuser/docker.proxy' >> .crowdr/hooks/build.before
+    $ echo 'echo pulling repos' > .crowdr/hooks/before.build
+    $ echo 'git clone http://github.com/someuser/docker.redis' >> .crowdr/hooks/before.build
+    $ echo 'git clone http://github.com/someuser/docker.proxy' >> .crowdr/hooks/before.build
     $ chmod 755 .crowdr/hooks/*
     $ crowdr build
     pulling repos
 
-Crowdr detects both `.before` and `.after` hooks of each crowdr command.
+Crowdr detects both `before.*` and `after.*` hooks of each crowdr command.
 
 Crowdr supports also hooks executed only for specified containers. See `before.*` and `after.*` in [crowdr options](#crowdr-options).

--- a/README.md
+++ b/README.md
@@ -1,23 +1,18 @@
-<p align="center">
-<b><a href="#features">Features</a></b>
-|
-<b><a href="#installation">Installation</a></b>
-|
-<b><a href="#quick-start-guide">Quick-start guide</a></b>
-|
-<b><a href="#configuration">Configuration</a></b>
-|
-<b><a href="#commands">Commands</a></b>
-|
-<b><a href="#hooks">Hooks</a></b>
-</p>
-
-<br>
-
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/polonskiy/crowdr/blob/master/LICENSE)
-[![Current Version](https://img.shields.io/badge/version-0.10.1-green.svg)](https://github.com/polonskiy/crowdr)
+# Crowdr [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/polonskiy/crowdr/blob/master/LICENSE) [![Current Version](https://img.shields.io/badge/version-0.11.0-green.svg)](https://github.com/polonskiy/crowdr)
 
 Extremely flexible tool for managing groups of docker containers.
+
+[Features](#features)
+
+[Installation](#installation)
+
+[Quick-start guide](#quick-start-guide)
+
+[Configuration](#configuration)
+
+[Commands](#commands)
+
+[Hooks](#hooks)
 
 # Features
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Yes, that's all. No need for additional libraries or execution environments.
 
 # Quick-start guide
 
-Crowdr can be used both with the newest features of docker 1.9 (like [named values](https://docs.docker.com/engine/userguide/dockervolumes/#mount-a-host-directory-as-a-data-volume) and [user-defined networks](https://docs.docker.com/engine/userguide/networking/dockernetworks/#user-defined-networks)) as with the older version of docker.  
+Crowdr can be used both with the newest features of docker 1.9 (like [named values](https://docs.docker.com/engine/userguide/dockervolumes/#mount-a-host-directory-as-a-data-volume) and [user-defined networks](https://docs.docker.com/engine/userguide/networking/dockernetworks/#user-defined-networks)) as with the older version of docker.
 
 ### Docker 1.9 example
 
@@ -176,7 +176,7 @@ After executing `crowdr run` the following command will be run:
 docker run -td \
            --name   example02-postgresql \
            --env    POSTGRES_PASSWORD=secretpass \
-           --volume postgresql-data:/var/lib/postgresql/data \       
+           --volume postgresql-data:/var/lib/postgresql/data \
            postgres:9.4.5
 ```
 


### PR DESCRIPTION
- added missing hooks
- prefixed all internals
- added new flexible config format
- added docker options passing to kill/rm/rmi/ps/stop commands
- refactored internals

New config example (it works!):

``` bash
#!/bin/bash

crowdr_project="example"
crowdr_name_format="%s_%s"

crowdr_config="
database env DB_NAME=gitlabhq_production
database env DB_USER=gitlab
database env DB_PASS=password
database volume $(crowdr_fullname database):/var/lib/postgresql
database image sameersbn/postgresql:9.4-11
database before.run create_volume database
database after.start wait_port database 5432

redis volume $(crowdr_fullname redis):/var/lib/redis
redis image sameersbn/redis:latest
redis before.run create_volume redis
redis after.start wait_port redis 6379

gitlab before.run create_volume gitlab
gitlab after.start wait_gitlab
gitlab link database:postgresql
gitlab link redis:redisio
gitlab publish 10022:22
gitlab publish 10080:80
gitlab env GITLAB_PORT=10080
gitlab env GITLAB_SSH_PORT=10022
gitlab env GITLAB_SECRETS_DB_KEY_BASE=long-and-random-alpha-numeric-string
gitlab volume $(crowdr_fullname gitlab):/home/git/data
gitlab image sameersbn/gitlab:8.3.2
"

create_volume() {
    docker volume create --name=$(crowdr_fullname $1) > /dev/null
}

wait_port() {
    ip=$(docker inspect --format '{{.NetworkSettings.IPAddress}}' $(crowdr_fullname $1))
    echo "Waiting for $1"
    while ! nc -q 1 $ip $2 </dev/null >/dev/null; do
        echo -n .
        sleep 1;
    done
    echo
}

wait_gitlab() {
    echo "Waiting for gitlab"
    while ! curl -ILs http://localhost:10080 | grep -q '200 OK'; do
        echo -n .
        sleep 1;
    done
    echo
    xdg-open http://localhost:10080
}
```

Readme is in progress.

What do you think?

@coderofsalvation
@byrnedo
@superm00s
@marcinwaldowski
