### PR TITLE
usage() + hook fix in DRY mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ create_volume() {
 wait_port() {
     ip=$(docker inspect --format '{{.NetworkSettings.IPAddress}}' $(crowdr_fullname $1))
     echo "Waiting for $1"
-    while ! nc -q 1 $ip $2 </dev/null >/dev/null; do
+    while ! nc -q 1 $ip $2 </dev/null &>/dev/null; do
         echo -n .
         sleep 1;
     done

--- a/crowdr
+++ b/crowdr
@@ -8,6 +8,7 @@ if [[ ! -n "$CROWDR_CFG" ]]; then
         CROWDR_CFG="crowdr.cfg.sh"
     fi
 fi
+crowdr_version="0.11.0"
 crowdr_dir="$(dirname $CROWDR_CFG)"
 crowdr_hookdir="$crowdr_dir/hooks"
 if [[ -n "$CROWDR_DRY" ]]; then
@@ -38,11 +39,12 @@ crowdr_fullname() {
 crowdr_run_hook(){
     local container="$1"
     local hook="$2"
+    [[ -n $CROWDR_DRY ]] && echo ${opts_hook["${container}~$hook"]} && return 0
     [[ -n ${crowdr_opts_hook["${container}~$hook"]} ]] && ${crowdr_opts_hook["${container}~$hook"]}
 }
 
 crowdr_command_version() {
-    echo "0.11.0"
+    echo "$crowdr_version"
 }
 
 crowdr_command_build() {
@@ -220,7 +222,14 @@ crowdr_parse_cfg() {
     crowdr_full_reversed=$(tac <<< "$crowdr_full_ordered")
 }
 
-cmd="${1:-run}"
+usage() {
+  echo -e "Usage: "
+  grep '^crowdr_command_*' $0 | sed 's/crowdr_command_/  crowdr /g;s/().*/   /g;' | grep -v cmd 
+  echo -e "\nCrowdr v$(crowdr_command_version) (docs @ https://github.com/polonskiy/crowdr)\n"
+}
+
+[[ ! -n $1 ]] && { usage && exit ; }
+cmd="$1"
 shift
 if [[ "$cmd" != "version" ]]; then
     crowdr_parse_cfg


### PR DESCRIPTION
Nice..converted an old crowdr cloudconfig to the new format..seems to work ok.
Anyways, this is the only tweak i made:
- added usage() as default command 

> I got burned already several times by running 'crowdr' without args (in unix this usually displays subcommands, unless it expects a pipe input). However currently without args crowdr **will stop and start all containers** :) which is quite catastrophic in a production environment. Now running crowdr without args will print this:

```
    $ crowdr 
    Usage: 
      crowdr version   
      crowdr build   
      crowdr run   
      crowdr start   
      crowdr stop   
      crowdr stats   
      crowdr ps   
      crowdr ip   
      crowdr shell   
      crowdr exec   
      crowdr pipe   
      crowdr restart   
      crowdr kill   
      crowdr rm   
      crowdr rmi   

    Crowdr v0.11.0 (docs @ https://github.com/polonskiy/crowdr)
```
- hook fix in DRY mode

> DRY mode was broken because the hooks were executed instead of printed.
> now the hook is echo'd in dry mode (CROWDR_DRY=1)
